### PR TITLE
#8 管理者管理のバリデーション周りの実装をする。

### DIFF
--- a/laravel/app/Http/Controllers/Api/AdminUserController.php
+++ b/laravel/app/Http/Controllers/Api/AdminUserController.php
@@ -63,12 +63,18 @@ class AdminUserController extends ApiController
      * 管理者編集
      *
      * @param  \Illuminate\Http\Request  $request
+     * @param int $id
      * @return JsonResponse
      */
-    public function update(AdminUserUpdateRequest $request, $id): JsonResponse
+    public function update(AdminUserUpdateRequest $request, int $id): JsonResponse
     {
         try {
-            $validated = $request->validationData();
+            $validated = $request->validated();
+
+            if (isset($validated['password'])) {
+                $validated['password'] = Hash::make($validated['password']);
+            }
+
             $adminUser = AdminUser::findOrFail($id);
             $adminUser->fill($validated);
             $adminUser->save();

--- a/laravel/app/Http/Requests/AdminUserStoreRequest.php
+++ b/laravel/app/Http/Requests/AdminUserStoreRequest.php
@@ -2,6 +2,9 @@
 
 namespace App\Http\Requests;
 
+use Illuminate\Validation\Rule;
+use App\Rules\PasswordRule;
+
 class AdminUserStoreRequest extends ApiRequest
 {
     /**
@@ -23,8 +26,8 @@ class AdminUserStoreRequest extends ApiRequest
     {
         return [
             'name' => 'required',
-            'email' => 'required',
-            'password' => 'required'
+            'email' => ['required', Rule::unique('admin_users')],
+            'password' => ['required', new PasswordRule()],
         ];
     }
 
@@ -33,6 +36,7 @@ class AdminUserStoreRequest extends ApiRequest
         return [
             'name.required' => '名前は必須です。',
             'email.required' => 'Eメールは必須です。',
+            'email.unique' => 'Eメールはすでに存在しています',
             'password.required' => 'パスワードは必須です。',
         ];
     }

--- a/laravel/app/Http/Requests/AdminUserUpdateRequest.php
+++ b/laravel/app/Http/Requests/AdminUserUpdateRequest.php
@@ -3,6 +3,8 @@
 namespace App\Http\Requests;
 
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\Rule;
+use App\Rules\PasswordRule;
 use App\AdminUser;
 
 class AdminUserUpdateRequest extends ApiRequest
@@ -12,7 +14,7 @@ class AdminUserUpdateRequest extends ApiRequest
      *
      * @return bool
      */
-    public function authorize()
+    public function authorize(): bool
     {
         return true;
     }
@@ -24,30 +26,21 @@ class AdminUserUpdateRequest extends ApiRequest
      */
     public function rules(): array
     {
+
         return [
+            'id' => 'required',
             'name' => 'required',
-            'email' => 'required',
-            'password' => 'nullable'
+            'email' => ['required', Rule::unique('App\AdminUser')->ignore($this->id)],
+            'password' => new PasswordRule(),
         ];
     }
 
-    public function messages()
+    public function messages(): array
     {
         return [
             'name.required' => '名前は必須です。',
             'email.required' => 'Eメールは必須です。',
-            'password.required' => 'パスワードは必須です。',
+            'email.unique' => '入力したEメールはすでに存在しています。',
         ];
-    }
-
-    public function validationData()
-    {
-        $data = $this->all();
-
-        if (isset($data['password'])) {
-            $data['password'] = Hash::make($data['password']);
-        }
-
-        return $data;
     }
 }

--- a/laravel/app/Rules/PasswordRule.php
+++ b/laravel/app/Rules/PasswordRule.php
@@ -8,6 +8,7 @@ class PasswordRule implements Rule
 {
     /**
      * パスワードは大文字、小文字、数字をそれぞれ最低1つ以上含み、かつ8文字以上
+     * （ローカルのみ6文字以上のパスワードを設定できる）
      *
      * @param  string  $attribute
      * @param  mixed  $value
@@ -15,7 +16,7 @@ class PasswordRule implements Rule
      */
     public function passes($attribute, $value): bool
     {
-        return preg_match('/^.*(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9]).*$/', $value);
+        return app()->isProduction() ? preg_match('/^.*(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9]).*$/', $value) : mb_strlen($value) >= 6;
     }
 
     /**

--- a/laravel/app/Rules/PasswordRule.php
+++ b/laravel/app/Rules/PasswordRule.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class PasswordRule implements Rule
+{
+    /**
+     * パスワードは大文字、小文字、数字をそれぞれ最低1つ以上含み、かつ8文字以上
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value): bool
+    {
+        return preg_match('/^.*(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9]).*$/', $value);
+    }
+
+    /**
+     * フォームに表示するエラーメッセージを設定
+     *
+     * @return string
+     */
+    public function message(): string
+    {
+        return 'パスワードには大文字小文字数字をそれぞれ最低1つ以上含み、かつ8文字以上のものを設定してください。';
+    }
+}

--- a/nuxt/components/admin/admin/Create.vue
+++ b/nuxt/components/admin/admin/Create.vue
@@ -2,17 +2,18 @@
   <v-card v-show="dialog">
     <v-card-title>
       <span class="text-h5">管理者登録</span>
-      <div v-if="Object.keys(validationErrors).length > 0">
-        <v-alert
-          v-for="(value, key) in validationErrors"
-          :key="key"
-          type="error"
-        >
-          {{ value[0] }}
-        </v-alert>
-      </div>
     </v-card-title>
-
+    <div v-if="Object.keys(validationErrors).length > 0">
+      <v-alert
+        v-for="(value, key) in validationErrors"
+        :key="key"
+        type="error"
+        width="580px"
+        class="mx-auto pa-3 ma-2 text-body-2"
+      >
+        {{ value[0] }}
+      </v-alert>
+    </div>
     <v-card-text>
       <v-form @submit.prevent="submit">
         <validation-provider v-slot="{ errors }" name="Name" rules="required">

--- a/nuxt/components/admin/admin/Edit.vue
+++ b/nuxt/components/admin/admin/Edit.vue
@@ -1,15 +1,25 @@
  <template :ref="openEditModal">
-  <v-dialog v-model="dialog" width="500">
+  <v-dialog v-model="dialog" width="600px">
     <v-card>
       <v-card-title>
         <span class="text-h5">管理者編集</span>
       </v-card-title>
-
+      <div v-if="Object.keys(validationErrors).length > 0">
+        <v-alert
+          v-for="(value, key) in validationErrors"
+          :key="key"
+          type="error"
+          width="580px"
+          class="mx-auto pa-3 ma-2 text-body-2"
+        >
+          {{ value[0] }}
+        </v-alert>
+      </div>
       <v-card-text>
         <v-form @submit.prevent="submit">
           <validation-provider v-slot="{ errors }" name="Name" rules="required">
             <v-text-field
-              v-model="form.name"
+              v-model="admin.name"
               label="Name"
               :error-messages="errors"
               prepend-icon="mdi-account-circle"
@@ -20,10 +30,10 @@
           <validation-provider
             v-slot="{ errors }"
             name="Email"
-            rules="required"
+            rules="required|email"
           >
             <v-text-field
-              v-model="form.email"
+              v-model="admin.email"
               label="Email"
               :error-messages="errors"
               prepend-icon="mdi-account-circle"
@@ -34,15 +44,17 @@
           <validation-provider
             v-slot="{ errors }"
             name="password"
-            rules="required"
+            :rules="{
+              min: 8,
+              regex: '^.*(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9]).*$',
+            }"
           >
             <v-text-field
               type="password"
-              v-model="form.password"
+              v-model="admin.password"
               label="Password"
               :error-messages="errors"
               prepend-icon="mdi-lock"
-              required
             ></v-text-field>
           </validation-provider>
         </v-form>
@@ -62,7 +74,7 @@ export default {
   name: "Edit",
   data() {
     return {
-      form: {},
+      admin: {},
       dialog: false,
     };
   },
@@ -71,17 +83,18 @@ export default {
       this.dialog = false;
     },
     open(item) {
-      this.form = item;
+      this.admin = item;
       this.dialog = true;
     },
     async save() {
       let params = {
-        name: this.form.name,
-        email: this.form.email,
-        passsword: this.form.passsword,
+        id: this.admin.id,
+        name: this.admin.name,
+        email: this.admin.email,
+        password: this.admin.password,
       };
       this.$axios
-        .$put(`/admins/${this.form.id}`, params)
+        .$put(`/admins/${this.admin.id}`, params)
         .then((res) => {
           this.$toast.global.success_message();
           this.close();

--- a/nuxt/pages/admin/list.vue
+++ b/nuxt/pages/admin/list.vue
@@ -13,7 +13,7 @@
           <v-toolbar-title>管理者管理</v-toolbar-title>
           <v-divider class="mx-4" inset vertical></v-divider>
           <v-spacer></v-spacer>
-          <v-dialog v-model="dialog" width="400px">
+          <v-dialog v-model="dialog" width="600px">
             <template v-slot:activator="{ on, attrs }">
               <v-row justify="end" class="mr-1">
                 <v-btn color="primary" dark v-bind="attrs" v-on="on">

--- a/nuxt/plugins/vee-validate.js
+++ b/nuxt/plugins/vee-validate.js
@@ -6,7 +6,17 @@ import ja from 'vee-validate/dist/locale/ja.json'
 // すべてのバリデーションルールをインポート
 Object.keys(rules).forEach((rule) => {
   extend(rule, rules[rule])
+
+  if (rule === 'regex') {
+    let regex = rules[rule]
+    extend('regex', {
+      ...regex,
+      message: 'パスワードには大文字小文字数字をそれぞれ最低1つ以上含めてください。',
+    })
+  }
 })
+
+
 
 localize('ja', ja)
 


### PR DESCRIPTION
## チケットへのリンク

*  #8 

## やったこと

* バリデーションルールの実装と強化
  - パスワードやEメールなどのバリデーションルールの強化
  - バリデーションエラーメッセージの日本語化とデザインの調整
  -  管理者編集時に自身のIDはバリデーションを通過させるように設定

## やらないこと

* 無し

## できるようになること（ユーザ目線）

* 管理者に、よりセキュアなパスワードを要求できるようになる

## できなくなること（ユーザ目線）

* 無し

## 動作確認

* 管理者登録と管理者編集フォームをぽちぽち